### PR TITLE
Fix panic when listing serverless instances

### DIFF
--- a/internal/show/minimal/minimal.go
+++ b/internal/show/minimal/minimal.go
@@ -11,7 +11,6 @@ package minimal
 import (
 	"bytes"
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/lynn9388/supsub"
@@ -33,13 +32,20 @@ var (
 				zone = n.Zones[0]
 			}
 			az := zone[len(zone)-2:]
-			cpu := strconv.Itoa(n.Compute.CPU.Cores)
+
+			cpu := "-"
+			mem := "-"
+			if n.Compute != nil {
+				cpu = fmt.Sprintf("%dx", n.Compute.CPU.Cores)
+				mem = n.Compute.Memory.Size.String()
+			}
+
 			role := ""
 			if n.ReadOnly {
 				role = "ro"
 			}
 
-			text := fmt.Sprintf("%2s %-17s %-6s %-15s %2sx %7s %8s %-6s %2s %s\n", az, n.Engine.ID, n.Engine.Version, n.Type, cpu, n.Compute.Memory.Size, n.Storage.Size, n.Storage.Type, role, n.Name)
+			text := fmt.Sprintf("%2s %-17s %-6s %-15s %3s %7s %8s %-6s %2s %s\n", az, n.Engine.ID, n.Engine.Version, n.Type, cpu, mem, n.Storage.Size, n.Storage.Type, role, n.Name)
 			return []byte(text), nil
 		},
 	)

--- a/internal/show/verbose/verbose.go
+++ b/internal/show/verbose/verbose.go
@@ -34,6 +34,13 @@ var (
 	//       Zones ¦ eu-central-1b
 	showConfigNode = show.FromShow[types.Node](
 		func(node types.Node) ([]byte, error) {
+			cpu := "-"
+			mem := "-"
+			if node.Compute != nil {
+				cpu = node.Compute.CPU.String()
+				mem = node.Compute.Memory.String()
+			}
+
 			ro := ""
 			if node.ReadOnly {
 				ro = " (read-only)"
@@ -43,8 +50,8 @@ var (
 			b.WriteString(fmt.Sprintf("\n%s%s\n", node.Name, ro))
 			b.WriteString(fmt.Sprintf("\t%9s ¦ %s\n", "Engine", node.Engine))
 			b.WriteString(fmt.Sprintf("\t%9s ¦ %s\n", "Instance", node.Type))
-			b.WriteString(fmt.Sprintf("\t%9s ¦ %s\n", "CPU", node.Compute.CPU))
-			b.WriteString(fmt.Sprintf("\t%9s ¦ %s\n", "Memory", node.Compute.Memory))
+			b.WriteString(fmt.Sprintf("\t%9s ¦ %s\n", "CPU", cpu))
+			b.WriteString(fmt.Sprintf("\t%9s ¦ %s\n", "Memory", mem))
 			b.WriteString(fmt.Sprintf("\t%9s ¦ %s\n", "Storage", node.Storage))
 			b.WriteString(fmt.Sprintf("\t%9s ¦ %s\n", "Zones", strings.Join(node.Zones, ", ")))
 			return b.Bytes(), nil
@@ -126,6 +133,13 @@ var (
 		func(node types.StatusNode) ([]byte, error) {
 			status := show.StatusText(node.Status)
 
+			cpu := "-"
+			mem := "-"
+			if node.Node.Compute != nil {
+				cpu = node.Node.Compute.CPU.String()
+				mem = node.Node.Compute.Memory.String()
+			}
+
 			ro := ""
 			if node.Node.ReadOnly {
 				ro = " (read-only)"
@@ -135,8 +149,8 @@ var (
 			b.WriteString(fmt.Sprintf("%s %s%s\n", status, node.Node.Name, ro))
 			b.WriteString(fmt.Sprintf("%14s ¦ %s\n", "Engine", node.Node.Engine))
 			b.WriteString(fmt.Sprintf("%14s ¦ %s\n", "Instance", node.Node.Type))
-			b.WriteString(fmt.Sprintf("%14s ¦ %s\n", "CPU", node.Node.Compute.CPU))
-			b.WriteString(fmt.Sprintf("%14s ¦ %s\n", "Memory", node.Node.Compute.Memory))
+			b.WriteString(fmt.Sprintf("%14s ¦ %s\n", "CPU", cpu))
+			b.WriteString(fmt.Sprintf("%14s ¦ %s\n", "Memory", mem))
 			b.WriteString(fmt.Sprintf("%14s ¦ %s\n", "Storage", node.Node.Storage))
 			b.WriteString(fmt.Sprintf("%14s ¦ %s\n\n", "Zones", strings.Join(node.Node.Zones, ", ")))
 			return b.Bytes(), nil


### PR DESCRIPTION
This change fixes the panics during listing the Aurora Serverless instances (`db.serverless`). The solution is to print dashes whenever compute data is not available.

<details>
<summary><code>rds-health list</code></summary>

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x104d31c7c]

goroutine 1 [running]:
github.com/zalando/rds-health/internal/show/minimal.init.func1({{0x1400036a1e0, 0x1d}, {0x140002beae0, 0x28}, {0x140002a5480, 0xd}, {0x14000405000, 0x1, 0x1}, 0x14000426960, ...})
	/Users/krzysiu/go/pkg/mod/github.com/zalando/rds-health@v0.0.2/internal/show/minimal/minimal.go:36 +0x8c
github.com/zalando/rds-health/internal/show.FromShow[...].Show(...)
	/Users/krzysiu/go/pkg/mod/github.com/zalando/rds-health@v0.0.2/internal/show/show.go:31
github.com/zalando/rds-health/internal/show.Seq[...].Show(0x1400012a1c0?, {0x140001eb180?, 0x69?, 0x70?})
	/Users/krzysiu/go/pkg/mod/github.com/zalando/rds-health@v0.0.2/internal/show/show.go:75 +0xd8
github.com/zalando/rds-health/internal/show.Printer2[...].Show(0x14000534750?, {{0x140002fb580, 0x1d}, 0x140004263e0, {0x140001eb1f0, 0x1?, 0x1?}, {0x140001eb180?, 0x1?, 0x1?}})
	/Users/krzysiu/go/pkg/mod/github.com/zalando/rds-health@v0.0.2/internal/show/show.go:104 +0xc8
github.com/zalando/rds-health/internal/show.Printer2[...].Show(0x0?, {{0x140002fb580, 0x1d}, 0x140004263e0, {0x140001eb1f0, 0x1?, 0x1?}, {0x140001eb180?, 0x1?, 0x1?}})
	/Users/krzysiu/go/pkg/mod/github.com/zalando/rds-health@v0.0.2/internal/show/show.go:115 +0x2c8
github.com/zalando/rds-health/internal/show.Seq[...].Show(0x106864be0?, {0x14000000fc0?, 0x1400036be00?, 0x4?})
	/Users/krzysiu/go/pkg/mod/github.com/zalando/rds-health@v0.0.2/internal/show/show.go:75 +0xc8
github.com/zalando/rds-health/internal/show/minimal.init.Region[...].FMap.func32()
	/Users/krzysiu/go/pkg/mod/github.com/zalando/rds-health@v0.0.2/internal/show/show.go:40 +0x58
github.com/zalando/rds-health/internal/show.FromShow[...].Show(...)
	/Users/krzysiu/go/pkg/mod/github.com/zalando/rds-health@v0.0.2/internal/show/show.go:31
github.com/zalando/rds-health/internal/show.Printer2[...].Show(0x104b68ae0?, {{0x14000000fc0, 0x4, 0x4}, {0x140001eb490, 0x1?, 0x1?}})
	/Users/krzysiu/go/pkg/mod/github.com/zalando/rds-health@v0.0.2/internal/show/show.go:104 +0xac
github.com/zalando/rds-health/internal/show/minimal.init.Prefix[...].FMap.func24()
	/Users/krzysiu/go/pkg/mod/github.com/zalando/rds-health@v0.0.2/internal/show/show.go:40 +0x78
github.com/zalando/rds-health/internal/show.FromShow[...].Show(...)
	/Users/krzysiu/go/pkg/mod/github.com/zalando/rds-health@v0.0.2/internal/show/show.go:31
github.com/zalando/rds-health/cmd.list(0x10685f1c0?, {0xc?, 0x10607b1a0?, 0x1400005b700?}, {0x106098d28?, 0x1400000e480?})
	/Users/krzysiu/go/pkg/mod/github.com/zalando/rds-health@v0.0.2/cmd/list.go:58 +0x16c
github.com/zalando/rds-health/cmd.init.WithService.func1(0x10685f1c0, {0x1068cba60, 0x0, 0x0})
	/Users/krzysiu/go/pkg/mod/github.com/zalando/rds-health@v0.0.2/cmd/root.go:230 +0x138
github.com/spf13/cobra.(*Command).execute(0x10685f1c0, {0x1068cba60, 0x0, 0x0})
	/Users/krzysiu/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:856 +0x568
github.com/spf13/cobra.(*Command).ExecuteC(0x10685f6c0)
	/Users/krzysiu/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:974 +0x318
github.com/spf13/cobra.(*Command).Execute(...)
	/Users/krzysiu/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:902
github.com/zalando/rds-health/cmd.Execute({0x140000487b0?, 0x16?})
	/Users/krzysiu/go/pkg/mod/github.com/zalando/rds-health@v0.0.2/cmd/root.go:29 +0x54
main.main()
	/Users/krzysiu/go/pkg/mod/github.com/zalando/rds-health@v0.0.2/main.go:25 +0xc4
```
</details>

<details>
<summary><code>rds-health list -v</code></summary>

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x10029002c]

goroutine 1 [running]:
github.com/zalando/rds-health/internal/show/verbose.init.func1({{0x14000325720, 0x1d}, {0x140003a4570, 0x28}, {0x14000395110, 0xd}, {0x14000448530, 0x1, 0x1}, 0x1400044db80, ...})
	/Users/krzysiu/go/pkg/mod/github.com/zalando/rds-health@v0.0.2/internal/show/verbose/verbose.go:46 +0x1cc
github.com/zalando/rds-health/internal/show.FromShow[...].Show(...)
	/Users/krzysiu/go/pkg/mod/github.com/zalando/rds-health@v0.0.2/internal/show/show.go:31
github.com/zalando/rds-health/internal/show.Seq[...].Show(0x28?, {0x140002690a0?, 0xd?, 0x14000448540?})
	/Users/krzysiu/go/pkg/mod/github.com/zalando/rds-health@v0.0.2/internal/show/show.go:75 +0xd8
github.com/zalando/rds-health/internal/show.Printer2[...].Show(0x1015cd4b0?, {{0x14000045980, 0x1d}, 0x1400044d500, {0x14000269110, 0x1?, 0x1?}, {0x140002690a0?, 0x1?, 0x1?}})
	/Users/krzysiu/go/pkg/mod/github.com/zalando/rds-health@v0.0.2/internal/show/show.go:104 +0xc8
github.com/zalando/rds-health/internal/show.Printer2[...].Show(0x0?, {{0x14000045980, 0x1d}, 0x1400044d500, {0x14000269110, 0x1?, 0x1?}, {0x140002690a0?, 0x1?, 0x1?}})
	/Users/krzysiu/go/pkg/mod/github.com/zalando/rds-health@v0.0.2/internal/show/show.go:115 +0x2c8
github.com/zalando/rds-health/internal/show.Seq[...].Show(0x2?, {0x14000001b00?, 0x0?, 0x1?})
	/Users/krzysiu/go/pkg/mod/github.com/zalando/rds-health@v0.0.2/internal/show/show.go:75 +0xc8
github.com/zalando/rds-health/internal/show/verbose.init.Region[...].FMap.func16()
	/Users/krzysiu/go/pkg/mod/github.com/zalando/rds-health@v0.0.2/internal/show/show.go:40 +0x58
github.com/zalando/rds-health/internal/show.FromShow[...].Show(...)
	/Users/krzysiu/go/pkg/mod/github.com/zalando/rds-health@v0.0.2/internal/show/show.go:31
github.com/zalando/rds-health/internal/show.Printer2[...].Show(0x101074b80?, {{0x14000001b00, 0x4, 0x4}, {0x140002693b0, 0x1?, 0x1?}})
	/Users/krzysiu/go/pkg/mod/github.com/zalando/rds-health@v0.0.2/internal/show/show.go:104 +0xac
github.com/zalando/rds-health/cmd.list(0x140002e8ef0?, {0xc?, 0x1015cf1a0?, 0x140001fd680?}, {0x1015ecd28?, 0x1400019c480?})
	/Users/krzysiu/go/pkg/mod/github.com/zalando/rds-health@v0.0.2/cmd/list.go:58 +0x16c
github.com/zalando/rds-health/cmd.init.WithService.func1(0x101db31c0, {0x140001a9420, 0x0, 0x1})
	/Users/krzysiu/go/pkg/mod/github.com/zalando/rds-health@v0.0.2/cmd/root.go:230 +0x138
github.com/spf13/cobra.(*Command).execute(0x101db31c0, {0x140001a9410, 0x1, 0x1})
	/Users/krzysiu/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:856 +0x568
github.com/spf13/cobra.(*Command).ExecuteC(0x101db36c0)
	/Users/krzysiu/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:974 +0x318
github.com/spf13/cobra.(*Command).Execute(...)
	/Users/krzysiu/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:902
github.com/zalando/rds-health/cmd.Execute({0x140001c4720?, 0x16?})
	/Users/krzysiu/go/pkg/mod/github.com/zalando/rds-health@v0.0.2/cmd/root.go:29 +0x54
main.main()
	/Users/krzysiu/go/pkg/mod/github.com/zalando/rds-health@v0.0.2/main.go:25 +0xc4
```
</details>